### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+### v1.0.0 - [changes](https://github.com/Urigo/meteor-static-html-compiler/blob/master/CHANGELOG.md#v100)
+
 ### v0.1.3 - [changes](https://github.com/Urigo/meteor-static-html-compiler/blob/master/CHANGELOG.md#v018)
 
 ### v0.1.2 - [changes](https://github.com/Urigo/meteor-static-html-compiler/blob/master/CHANGELOG.md#v017)

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'urigo:static-templates',
-  version: '0.1.3',
+  version: '1.0.0',
   summary: 'Meteor plugin for importing static HTML templates'
 });
 
@@ -10,13 +10,13 @@ Package.registerBuildPlugin({
     'plugin.js'
   ],
   use: [
-    'urigo:static-html-compiler@0.1.8',
+    'urigo:static-html-compiler@1.0.0',
     'ecmascript@0.2.0'
   ]
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom('1.3');
+  api.versionsFrom('1.6.1');
 
   api.use('isobuild:compiler-plugin@1.0.0');
 });


### PR DESCRIPTION
Dependent on `urigo:static-html-compiler@1.0.0` which inspired me to publish this also as a `1.0.0` release.

The link in the changelog will first work after https://github.com/Urigo/meteor-static-html-compiler/pull/24 has been merged and the package has been published as `1.0.0` in Atmosphere: https://github.com/Urigo/meteor-static-html-compiler/issues/23