### PR TITLE
Update compiler to remove double templates

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'urigo:static-templates',
-  version: '1.0.0_2',
+  version: '1.1.0',
   summary: 'Meteor plugin for importing static HTML templates'
 });
 
@@ -10,7 +10,7 @@ Package.registerBuildPlugin({
     'plugin.js'
   ],
   use: [
-    'urigo:static-html-compiler@1.0.0',
+    'urigo:static-html-compiler@1.1.1',
     'ecmascript@0.2.0'
   ]
 });


### PR DESCRIPTION
I just released `urigo:static-html-compiler@1.1.1`. Before all templates were included twice for some outdated angular 2 compatibility (angular 2+ should use https://github.com/Urigo/angular-meteor/tree/master/atmosphere-packages/angular-html-compiler ).

This can save some serious file size of the code bundle.